### PR TITLE
add: support for MAC

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Other Changes
+      labels:
+        - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## UnReleased
+
+- Supported Mac

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,19 @@ edition = "2021"
 bevy = { version = "0.15", default-features = false, features = [
     "bevy_window",
     "bevy_winit",
+    "serialize",
 ] }
-winit = { version = "=0.30.7"}
+winit = { version = "=0.30.7" }
+serde = { version = "1.0.217", features = ["derive"] }
 
 [dev-dependencies]
 bevy = "0.15"
+bevy_webview_wry = { path = "../bevy_webview_projects/crates/bevy_webview_wry" }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-objc2 = { version = "0.5" }
-objc2-app-kit = { version = "0.2.0", features = [
+block2 = { version = "0.5.1" }
+objc2 = { version = "0.5.2", features = ["std"] }
+objc2-app-kit = { version = "0.2.2", features = [
     "NSApplication",
     "NSEvent",
     "NSWindow",
@@ -28,5 +32,17 @@ objc2-app-kit = { version = "0.2.0", features = [
     "NSMenu",
     "NSGraphics",
     "NSTrackingArea",
+    "block2",
 ] }
 objc2-foundation = { version = "0.2.0" }
+
+[lints.clippy]
+type_complexity = "allow"
+doc_markdown = "warn"
+manual_let_else = "warn"
+redundant_else = "warn"
+match_same_arms = "warn"
+semicolon_if_nothing_returned = "warn"
+
+[lints.rust]
+missing_docs = "warn"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# bevy_child_window
+
+This library provides a way to create a child window in Bevy.
+
+## Supported platforms
+
+| Platform | usable |
+|----------|--------|
+| Windows  | ❌      |
+| MacOS    | ✅      |
+| Linux    | ❌      |
+| Web      | ❌      |
+
+## Usage
+
+You can create the window as child by adding `ParentWindow` component to the entity.
+
+```rust
+use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, WindowResolution};
+use bevy_child_window::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            ChildWindowPlugin,
+        ))
+        .add_systems(Startup, spawn_child_window)
+        .run();
+}
+
+fn spawn_child_window(
+    mut commands: Commands,
+    parent: Query<Entity, With<PrimaryWindow>>,
+) {
+    commands.spawn((
+        ParentWindow(parent.single()),
+        Window {
+            title: "Child Window".to_string(),
+            resolution: WindowResolution::new(500.0, 500.0),
+            ..Default::default()
+        }
+    ));
+}
+```
+
+## ChangeLog
+
+Please see [here](./CHANGELOG.md).
+
+## Compatible Bevy versions
+
+| bevy_child_window | bevy |
+|-------------------|------|
+| 0.1.0 ~           | 0.15 |
+
+## License
+
+This crate is licensed under the MIT License or the Apache License 2.0.
+
+## Contributing
+
+Welcome to contribute by PR and issues!
+
+
+

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,13 +1,15 @@
+//! This example demonstrates how to create a child window.
+
 use bevy::prelude::*;
 use bevy::window::{PrimaryWindow, WindowResolution};
-use bevy_child_window::BevyChildWindowPlugin;
+use bevy_child_window::prelude::*;
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            BevyChildWindowPlugin,
-            ))
+            ChildWindowPlugin,
+        ))
         .add_systems(Startup, spawn_child_window)
         .run();
 }
@@ -15,10 +17,13 @@ fn main() {
 fn spawn_child_window(
     mut commands: Commands,
     parent: Query<Entity, With<PrimaryWindow>>,
-){
-    commands.entity(parent.single()).with_child(Window{
-        title: "Child Window".to_string(),
-        resolution: WindowResolution::new(200., 200.),
-        ..default()
-    });
+) {
+    commands.spawn((
+        ParentWindow(parent.single()),
+        Window {
+            title: "Child Window".to_string(),
+            resolution: WindowResolution::new(500.0, 500.0),
+            ..Default::default()
+        }
+    ));
 }

--- a/src/platform_impl/macos.rs
+++ b/src/platform_impl/macos.rs
@@ -1,81 +1,313 @@
-use bevy::hierarchy::Parent;
-use bevy::math::{IVec2, Rect};
-use bevy::prelude::{Entity, EventReader, NonSend, Query, Vec2, WindowMoved, With, Without};
+mod resize;
+mod cursor;
+
+use crate::platform_impl::macos::cursor::{current_cursor_icon, to_resize_direction, RequestCursorChange, RequestCursorChangeSender};
+use crate::platform_impl::macos::resize::{resize_on_bottom_edge, resize_on_left_edge, resize_on_right_edge, resize_on_top_edge, resize_on_top_left_edge, resize_on_top_right_edge};
+use crate::{ParentWindow, UnInitializeWindow};
+use bevy::app::{App, Plugin, Update};
+use bevy::prelude::{Commands, Entity, NonSend, Query, ResMut, Resource, With};
+use bevy::utils::HashSet;
 use bevy::window::Window;
 use bevy::winit::WinitWindows;
+use block2::RcBlock;
+use objc2::ffi::NSInteger;
 use objc2::rc::{Id, Retained};
-use objc2_app_kit::{NSView, NSWindow, NSWindowOrderingMode};
-use winit::dpi::PhysicalPosition;
+use objc2::ClassType;
+use objc2_app_kit::{NSEvent, NSEventMask, NSEventType, NSView, NSWindow, NSWindowOrderingMode, NSWindowStyleMask};
+use objc2_foundation::{CGPoint, CGRect};
+use std::cell::Cell;
+use std::ptr::{null_mut, NonNull};
+use std::sync::mpsc::Sender;
 #[allow(deprecated)]
 use winit::raw_window_handle::HasRawWindowHandle;
 use winit::raw_window_handle::RawWindowHandle;
 
-pub fn set_parent(
-    child: &winit::window::Window,
-    parent: &winit::window::Window,
-){
-    let Some(child_window) = obtain_ns_window(child) else{
-        return;
-    };
-    let Some(parent_window) = obtain_ns_window(parent) else{
-       return;
-    };
-    unsafe {
-        parent_window.addChildWindow_ordered(&child_window, NSWindowOrderingMode::NSWindowAbove);
+pub struct ChildWindowPlugin;
+
+impl Plugin for ChildWindowPlugin {
+    fn build(&self, app: &mut App) {
+        let (sender, receiver) = std::sync::mpsc::channel::<RequestCursorChange>();
+        app
+            .insert_non_send_resource(cursor::RequestCursorChangeSender(sender))
+            .insert_non_send_resource(cursor::RequestCursorChangeReceiver(receiver))
+            .init_resource::<AlreadyRegisteredWindows>()
+            .add_systems(Update, (
+                convert_to_child_window,
+                cursor::change_cursor_system,
+            ));
     }
 }
 
-pub fn fit(
-    mut er: EventReader<WindowMoved>,
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum CurrentStatus {
+    None,
+    Moving(NSInteger),
+    Resizing {
+        target_window: NSInteger,
+        direction: ResizeDirection,
+    },
+    ResizeCursorVisible {
+        target_window: NSInteger,
+        direction: ResizeDirection,
+    },
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum ResizeDirection {
+    Left,
+    Right,
+    Top,
+    Bottom,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+#[derive(Resource, Default)]
+struct AlreadyRegisteredWindows(HashSet<Entity>);
+
+fn convert_to_child_window(
+    mut commands: Commands,
+    mut already_registered_windows: ResMut<AlreadyRegisteredWindows>,
     winit_windows: NonSend<WinitWindows>,
-     parents: Query<Entity, (With<Window>, Without<Parent>)>,
-    children: Query<(Entity, &Parent), With<Window>>,
-){
-    for e in er.read(){
-        let Ok((child_entity, parent)) = children.get(e.window) else{
+    request_cursor_change_sender: NonSend<RequestCursorChangeSender>,
+    windows: Query<(Entity, &ParentWindow), (With<Window>, With<UnInitializeWindow>)>,
+) {
+    for (entity, ParentWindow(parent_entity)) in windows.iter() {
+        let Some(child) = winit_windows.get_window(entity) else {
             continue;
         };
-        let Ok(parent_entity) = parents.get(parent.get()) else{
+        let Some(parent) = winit_windows.get_window(*parent_entity) else {
             continue;
         };
-        let Some(child_window) = winit_windows.get_window(e.window) else{
-            continue;
+        let Some(child_window) = obtain_ns_window(child) else {
+            return;
         };
-        let Some(parent_window) = winit_windows.get_window(parent_entity) else{
-            continue;
+        let Some(parent_window) = obtain_ns_window(parent) else {
+            return;
         };
-        fit_window_position(parent_window, child_window);
+        commands.entity(entity).remove::<UnInitializeWindow>();
+        settings_windows(&child_window, &parent_window);
+        if !already_registered_windows.0.contains(parent_entity) {
+            unsafe {
+                register_ns_event(request_cursor_change_sender.0.clone(), parent_window, *parent_entity);
+            }
+            already_registered_windows.0.insert(*parent_entity);
+        }
     }
+}
+
+fn settings_windows(
+    child_window: &NSWindow,
+    parent_window: &NSWindow,
+) {
+    unsafe {
+        parent_window.addChildWindow_ordered(child_window, NSWindowOrderingMode::NSWindowAbove);
+    }
+
+    child_window.setMovable(false);
+    child_window.setStyleMask(
+        NSWindowStyleMask::Titled |
+            NSWindowStyleMask::Closable
+    );
+}
+
+unsafe fn register_ns_event(
+    request_cursor_change_sender: Sender<RequestCursorChange>,
+    parent_window: Retained<NSWindow>,
+    parent_window_entity: Entity,
+) {
+    let status = Cell::new(CurrentStatus::None);
+    NSEvent::addLocalMonitorForEventsMatchingMask_handler(
+        NSEventMask::LeftMouseDragged | NSEventMask::LeftMouseDown | NSEventMask::LeftMouseUp | NSEventMask::MouseMoved,
+        Box::leak(Box::new(RcBlock::new(move |event: NonNull<NSEvent>| {
+            let e = &*event.as_ptr();
+            match (e.r#type(), status.get()) {
+                (NSEventType::LeftMouseDown, CurrentStatus::None) => {
+                    transition_to_move(&parent_window, &status, e);
+                }
+                (NSEventType::LeftMouseDown, CurrentStatus::ResizeCursorVisible {
+                    target_window,
+                    direction,
+                }) => {
+                    transition_to_resize(&parent_window, &status, target_window, direction);
+                }
+                (NSEventType::LeftMouseUp, _) => {
+                    status.set(CurrentStatus::None);
+                }
+                (NSEventType::MouseMoved, CurrentStatus::None | CurrentStatus::ResizeCursorVisible { direction: _, target_window: _ }) => {
+                    let (child_window, cursor_icon) = current_cursor_icon(&parent_window, e);
+                    let _ = request_cursor_change_sender.send(RequestCursorChange {
+                        parent_window: parent_window_entity,
+                        cursor_icon,
+                    });
+                    if let Some(resize_direction) = to_resize_direction(&cursor_icon) {
+                        status.set(CurrentStatus::ResizeCursorVisible {
+                            target_window: child_window,
+                            direction: resize_direction,
+                        });
+                    } else {
+                        status.set(CurrentStatus::None);
+                    }
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::Left,
+                }) => {
+                    resize_on_left_edge(&parent_window, target_window, e.deltaX());
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::Right,
+                }) => {
+                    resize_on_right_edge(&parent_window, target_window, e.deltaX());
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::Top,
+                }) => {
+                    resize_on_top_edge(&parent_window, target_window, e.deltaY());
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::Bottom,
+                }) => {
+                    resize_on_bottom_edge(&parent_window, target_window, e.deltaY());
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::TopLeft,
+                }) => {
+                    resize_on_top_left_edge(
+                        &parent_window,
+                        target_window,
+                        e.deltaX(),
+                        e.deltaY(),
+                    );
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::TopRight,
+                }) => {
+                    resize_on_top_right_edge(
+                        &parent_window,
+                        target_window,
+                        e.deltaX(),
+                        e.deltaY(),
+                    );
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::BottomLeft,
+                }) => {
+                    resize_on_left_edge(&parent_window, target_window, e.deltaX());
+                    resize_on_bottom_edge(&parent_window, target_window, e.deltaY());
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Resizing {
+                    target_window,
+                    direction: ResizeDirection::BottomRight,
+                }) => {
+                    resize_on_right_edge(&parent_window, target_window, e.deltaX());
+                    resize_on_bottom_edge(&parent_window, target_window, e.deltaY());
+                }
+                (NSEventType::LeftMouseDragged, CurrentStatus::Moving(target_num)) => {
+                    let Some(child_window) = find_child_window(&parent_window, target_num) else {
+                        return null_mut();
+                    };
+                    move_child_window(&parent_window, &child_window, e.deltaX(), e.deltaY());
+                }
+                _ => {}
+            }
+            event.as_ptr()
+        }))),
+    );
+}
+
+#[inline]
+unsafe fn move_child_window(
+    parent_window: &NSWindow,
+    child_window: &NSWindow,
+    delta_x: f64,
+    delta_y: f64,
+) {
+    let c = child_window.frame();
+    let p = parent_window.contentRectForFrameRect(parent_window.frame());
+    let x = p.origin.x.max(c.origin.x + delta_x);
+    let x = x.min(p.origin.x + p.size.width - c.size.width);
+    let y = c.origin.y - delta_y;
+    let y = p.origin.y.max(y);
+    let y = y.min(p.origin.y + p.size.height - c.size.height);
+
+    child_window.setFrame_display(CGRect::new(
+        CGPoint::new(x, y),
+        c.size,
+    ), false);
+}
+
+unsafe fn find_child_window(window: &NSWindow, window_num: NSInteger) -> Option<Retained<NSWindow>> {
+    for child in window.childWindows()?.iter() {
+        if child.windowNumber() == window_num {
+            return Some(child.retain());
+        }
+    }
+    None
 }
 
 fn obtain_ns_window(
     window: &winit::window::Window,
-) -> Option<Retained<NSWindow>>{
+) -> Option<Retained<NSWindow>> {
+    #[allow(deprecated)]
     let ns_window = window.raw_window_handle().ok()?;
     if let RawWindowHandle::AppKit(handle) = ns_window {
         let ns_ptr = handle.ns_view.as_ptr();
         let ns_view: Id<NSView> = unsafe { Id::retain(ns_ptr.cast())? };
         ns_view.window()
-    } else{
-            None
-        }
+    } else {
+        None
+    }
 }
 
-fn fit_window_position(
-    parent_window: &winit::window::Window,
-    child_window: &winit::window::Window,
-){
-    let Ok(child_pos) = child_window.outer_position() else{
-        return;;
+unsafe fn bring_to_front_child_window(
+    parent_window: &NSWindow,
+    child_window: &NSWindow,
+) {
+    parent_window.removeChildWindow(child_window);
+    if let Some(children) = parent_window.childWindows() {
+        for child in children.iter() {
+            if child.isKeyWindow() {
+                child.resignKeyWindow();
+            }
+        }
+    }
+    parent_window.addChildWindow_ordered(child_window, NSWindowOrderingMode::NSWindowAbove);
+    child_window.becomeKeyWindow();
+}
+
+unsafe fn transition_to_move(
+    parent_window: &NSWindow,
+    status: &Cell<CurrentStatus>,
+    e: &NSEvent,
+) {
+    if let Some(child_window) = find_child_window(parent_window, e.windowNumber()) {
+        if child_window.contentRectForFrameRect(child_window.frame()).size.height <= e.locationInWindow().y {
+            bring_to_front_child_window(parent_window, &child_window);
+            status.set(CurrentStatus::Moving(e.windowNumber()));
+        }
     };
-    let Ok(parent_pos) = parent_window.outer_position() else{
-        return;;
-    };
-    let child_size = child_window.outer_size().cast::<i32>();
-    let parent_size = parent_window.outer_size().cast::<i32>();
-    let p = IVec2::new(parent_pos.x + parent_size.width, parent_pos.y + parent_size.height);
-    let c = IVec2::new(child_pos.x + child_size.width, child_pos.y + child_size.height);
-    if child_pos.x < parent_pos.x{
-        child_window.set_outer_position(PhysicalPosition::new(parent_pos.x, child_pos.y));
+}
+
+unsafe fn transition_to_resize(
+    parent_window: &NSWindow,
+    status: &Cell<CurrentStatus>,
+    child_window_num: NSInteger,
+    resize_dir: ResizeDirection,
+) {
+    if let Some(child_window) = find_child_window(parent_window, child_window_num) {
+        bring_to_front_child_window(parent_window, &child_window);
+        status.set(CurrentStatus::Resizing {
+            target_window: child_window_num,
+            direction: resize_dir,
+        });
     }
 }

--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -1,0 +1,265 @@
+use crate::platform_impl::macos::ResizeDirection;
+use crate::ParentWindow;
+use bevy::math::{Rect, Vec2};
+use bevy::prelude::{Entity, NonSend, Query, With};
+use bevy::window::Window;
+use bevy::winit::WinitWindows;
+use objc2_app_kit::{NSEvent, NSWindow};
+use objc2_foundation::{NSInteger, NSPoint};
+use std::sync::mpsc::{Receiver, Sender};
+use winit::window::{Cursor, CursorIcon};
+
+#[derive(Debug)]
+pub struct RequestCursorChange {
+    pub parent_window: Entity,
+    pub cursor_icon: CursorIcon,
+}
+
+pub struct RequestCursorChangeSender(pub Sender<RequestCursorChange>);
+
+pub struct RequestCursorChangeReceiver(pub Receiver<RequestCursorChange>);
+
+pub fn change_cursor_system(
+    rx: NonSend<RequestCursorChangeReceiver>,
+    winit_windows: NonSend<WinitWindows>,
+    child_windows: Query<(Entity, &ParentWindow), With<Window>>,
+) {
+    if let Ok(request) = rx.0.try_recv() {
+        if let Some(parent) = winit_windows.get_window(request.parent_window) {
+            parent.set_cursor(Cursor::Icon(request.cursor_icon));
+        }
+        for child in child_windows
+            .iter()
+            .filter(|(_, parent)| parent.0 == request.parent_window) {
+            let Some(winit_window) = winit_windows.get_window(child.0) else {
+                continue;
+            };
+            winit_window.set_cursor(Cursor::Icon(request.cursor_icon));
+        }
+    }
+}
+
+pub unsafe fn current_cursor_icon(
+    parent: &NSWindow,
+    e: &NSEvent,
+) -> (NSInteger, CursorIcon) {
+    match find_hit_resizing_window(parent, e) {
+        Some((child, ResizeDirection::Left)) => {
+            (child, CursorIcon::WResize)
+        }
+        Some((child, ResizeDirection::Right)) => {
+            (child, CursorIcon::EResize)
+        }
+        Some((child, ResizeDirection::Top)) => {
+            (child, CursorIcon::NResize)
+        }
+        Some((child, ResizeDirection::Bottom)) => {
+            (child, CursorIcon::SResize)
+        }
+        Some((child, ResizeDirection::TopLeft)) => {
+            (child, CursorIcon::NwResize)
+        }
+        Some((child, ResizeDirection::TopRight)) => {
+            (child, CursorIcon::NeResize)
+        }
+        Some((child, ResizeDirection::BottomLeft)) => {
+            (child, CursorIcon::SwResize)
+        }
+        Some((child, ResizeDirection::BottomRight)) => {
+            (child, CursorIcon::SeResize)
+        }
+        None => {
+            (parent.windowNumber(), CursorIcon::Default)
+        }
+    }
+}
+
+pub fn to_resize_direction(icon: &CursorIcon) -> Option<ResizeDirection> {
+    match icon {
+        CursorIcon::WResize => Some(ResizeDirection::Left),
+        CursorIcon::EResize => Some(ResizeDirection::Right),
+        CursorIcon::NResize => Some(ResizeDirection::Top),
+        CursorIcon::SResize => Some(ResizeDirection::Bottom),
+        _ => None,
+    }
+}
+
+pub unsafe fn find_hit_resizing_window(
+    parent: &NSWindow,
+    e: &NSEvent,
+) -> Option<(NSInteger, ResizeDirection)> {
+    let within_parent = parent.windowNumber() == e.windowNumber();
+
+    let children = parent.childWindows()?;
+    let mut children = children.iter().collect::<Vec<_>>();
+    children.sort_by_key(|c| c.orderedIndex());
+
+    for child in children.iter().rev() {
+        let frame = child.frame();
+        let mouse_pos = if within_parent {
+            let pos = e.locationInWindow();
+            NSPoint::new(pos.x - frame.origin.x, pos.y - frame.origin.y)
+        } else {
+            e.locationInWindow()
+        };
+
+        let center = Vec2::new(
+            ((frame.max().x - frame.min().x) / 2.) as f32,
+            ((frame.max().y - frame.min().y) / 2.) as f32,
+        );
+        let size = Vec2::new(
+            (frame.size.width + OUTER_L) as f32,
+            (frame.size.height + OUTER_L) as f32,
+        );
+
+        if !Rect::from_center_size(center, size).contains(Vec2::new(mouse_pos.x as f32, mouse_pos.y as f32)) {
+            continue;
+        }
+        if let Some(dir) = check_resizable_direction(
+            frame.size.width,
+            frame.size.height,
+            mouse_pos.x,
+            mouse_pos.y,
+        ) {
+            return Some((child.windowNumber(), dir));
+        }
+    }
+
+    None
+}
+
+const INNER_L: f64 = 10.0;
+const OUTER_L: f64 = 20.0;
+
+fn check_resizable_direction(
+    w: f64,
+    h: f64,
+    x: f64,
+    y: f64,
+) -> Option<ResizeDirection> {
+    fn is_in_horizontal_resizable_space(x: f64) -> bool {
+        if x < 0. {
+            x.abs() <= OUTER_L
+        } else {
+            x <= INNER_L
+        }
+    }
+
+    fn is_in_vertical_resizable_space(y: f64) -> bool {
+        if y < 0. {
+            y.abs() <= INNER_L
+        } else {
+            y <= OUTER_L
+        }
+    }
+
+    let is_right = is_in_horizontal_resizable_space(w - x);
+    let is_left = is_in_horizontal_resizable_space(x);
+    let is_top = is_in_vertical_resizable_space(y - h);
+    let is_bottom = is_in_vertical_resizable_space(y);
+    if y.abs() <= OUTER_L && x <= OUTER_L {
+        Some(ResizeDirection::TopLeft)
+    } else if is_top && is_right {
+        Some(ResizeDirection::TopRight)
+    } else if is_bottom && is_left {
+        Some(ResizeDirection::BottomLeft)
+    } else if is_bottom && is_right {
+        Some(ResizeDirection::BottomRight)
+    } else if is_bottom {
+        Some(ResizeDirection::Bottom)
+    } else if is_left {
+        Some(ResizeDirection::Left)
+    } else if is_right {
+        Some(ResizeDirection::Right)
+    } else if is_top {
+        Some(ResizeDirection::Top)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::platform_impl::macos::cursor::{check_resizable_direction, INNER_L, OUTER_L};
+    use crate::platform_impl::macos::ResizeDirection;
+
+    #[test]
+    fn bottom() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            30.,
+            0.0,
+        ), Some(ResizeDirection::Bottom));
+    }
+
+    #[test]
+    fn left() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            0.,
+            30.0,
+        ), Some(ResizeDirection::Left));
+    }
+
+    #[test]
+    fn left_outer() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            -OUTER_L,
+            30.0,
+        ), Some(ResizeDirection::Left));
+    }
+
+    #[test]
+    fn un_change_left_outer() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            -OUTER_L - 1.0,
+            30.0,
+        ), None);
+    }
+
+    #[test]
+    fn right() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            100.,
+            30.0,
+        ), Some(ResizeDirection::Right));
+    }
+
+    #[test]
+    fn top() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            30.,
+            100.0,
+        ), Some(ResizeDirection::Top));
+    }
+
+    #[test]
+    fn top_outer() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            INNER_L + 1.0,
+            100. + OUTER_L,
+        ), Some(ResizeDirection::Top));
+    }
+
+    #[test]
+    fn top_left() {
+        assert_eq!(check_resizable_direction(
+            100.0,
+            100.0,
+            0.,
+            100.,
+        ), Some(ResizeDirection::TopLeft));
+    }
+}

--- a/src/platform_impl/macos/resize.rs
+++ b/src/platform_impl/macos/resize.rs
@@ -1,0 +1,304 @@
+use crate::platform_impl::macos::find_child_window;
+use objc2::ffi::NSInteger;
+use objc2_app_kit::NSWindow;
+use objc2_foundation::{CGPoint, CGRect, CGSize};
+
+pub unsafe fn resize_on_top_left_edge(
+    parent: &NSWindow,
+    target_window: NSInteger,
+    delta_x: f64,
+    delta_y: f64,
+) {
+    let Some(target_window) = find_child_window(parent, target_window) else {
+        return;
+    };
+    let frame = resize_left_frame(
+        parent.frame(),
+        target_window.frame(),
+        delta_x,
+        parent.minSize().width,
+    );
+    let frame = resize_top_frame(
+        parent.contentRectForFrameRect(parent.frame()),
+        frame,
+        delta_y,
+        target_window.minSize().height,
+    );
+    target_window.setFrame_display(frame, true);
+}
+
+pub unsafe fn resize_on_top_right_edge(
+    parent: &NSWindow,
+    target_window: NSInteger,
+    delta_x: f64,
+    delta_y: f64,
+) {
+    let Some(target_window) = find_child_window(parent, target_window) else {
+        return;
+    };
+    let frame = resize_right_frame(
+        parent.frame(),
+        target_window.frame(),
+        delta_x,
+        parent.minSize().width,
+    );
+    let frame = resize_top_frame(
+        parent.contentRectForFrameRect(parent.frame()),
+        frame,
+        delta_y,
+        target_window.minSize().height,
+    );
+    target_window.setFrame_display(frame, true);
+}
+
+pub unsafe fn resize_on_left_edge(
+    parent: &NSWindow,
+    target_window: NSInteger,
+    delta_x: f64,
+) {
+    let Some(target_window) = find_child_window(parent, target_window) else {
+        return;
+    };
+    let frame = resize_left_frame(
+        parent.frame(),
+        target_window.frame(),
+        delta_x,
+        parent.minSize().width,
+    );
+    target_window.setFrame_display(frame, true);
+}
+
+pub unsafe fn resize_on_right_edge(
+    parent: &NSWindow,
+    target_window: NSInteger,
+    delta_x: f64,
+) {
+    let Some(target_window) = find_child_window(parent, target_window) else {
+        return;
+    };
+    let frame = resize_right_frame(
+        parent.contentRectForFrameRect(parent.frame()),
+        target_window.frame(),
+        delta_x,
+        target_window.minSize().width,
+    );
+    target_window.setFrame_display(frame, true);
+}
+
+pub unsafe fn resize_on_top_edge(
+    parent: &NSWindow,
+    target_window: NSInteger,
+    delta_y: f64,
+) {
+    let Some(target_window) = find_child_window(parent, target_window) else {
+        return;
+    };
+    let frame = resize_top_frame(
+        parent.contentRectForFrameRect(parent.frame()),
+        target_window.frame(),
+        delta_y,
+        target_window.minSize().height,
+    );
+    target_window.setFrame_display(frame, true);
+}
+
+pub unsafe fn resize_on_bottom_edge(
+    parent: &NSWindow,
+    target_window: NSInteger,
+    delta_y: f64,
+) {
+    let Some(target_window) = find_child_window(parent, target_window) else {
+        return;
+    };
+    let frame = resize_bottom_frame(
+        parent.contentRectForFrameRect(parent.frame()),
+        target_window.frame(),
+        delta_y,
+        target_window.minSize().height,
+    );
+    target_window.setFrame_display(frame, true);
+}
+
+fn resize_left_frame(
+    parent: CGRect,
+    child: CGRect,
+    delta_x: f64,
+    min_width: f64,
+) -> CGRect {
+    if child.size.width - delta_x <= min_width {
+        return child;
+    }
+    let x = child.origin.x + delta_x;
+    let x = x.min(parent.origin.x + parent.size.width - min_width);
+    let x = x.max(parent.origin.x);
+    CGRect::new(
+        CGPoint::new(x, child.origin.y),
+        CGSize::new(child.size.width + child.origin.x - x, child.size.height),
+    )
+}
+
+fn resize_right_frame(
+    parent: CGRect,
+    child: CGRect,
+    delta_x: f64,
+    min_width: f64,
+) -> CGRect {
+    let width = (child.size.width + delta_x).max(min_width);
+    let width = width.max(min_width);
+    let width = width.min(parent.origin.x + parent.size.width - child.origin.x);
+    CGRect::new(
+        child.origin,
+        CGSize::new(width, child.size.height),
+    )
+}
+
+fn resize_top_frame(
+    parent: CGRect,
+    child: CGRect,
+    delta_y: f64,
+    min_height: f64,
+) -> CGRect {
+    let height = (child.size.height - delta_y).max(min_height);
+    let height = height.min(parent.origin.y + parent.size.height - child.origin.y);
+    CGRect::new(
+        child.origin,
+        CGSize::new(child.size.width, height),
+    )
+}
+
+fn resize_bottom_frame(
+    parent: CGRect,
+    child: CGRect,
+    delta_y: f64,
+    min_height: f64,
+) -> CGRect {
+    if child.size.height + delta_y <= min_height {
+        return child;
+    }
+    let y = parent.origin.y.max(child.origin.y - delta_y);
+    CGRect::new(
+        CGPoint::new(child.origin.x, y),
+        CGSize::new(child.size.width, child.size.height + child.origin.y - y),
+    )
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::platform_impl::macos::resize::{resize_right_frame, resize_top_frame};
+    use objc2_foundation::{CGPoint, CGRect, CGSize};
+
+    #[test]
+    fn resize_right_expand() {
+        assert_eq!(resize_right_frame(
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(100.0, 100.0),
+            ),
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(50.0, 50.0),
+            ),
+            10.,
+            50.,
+        ), CGRect::new(
+            CGPoint::new(0.0, 0.0),
+            CGSize::new(60.0, 50.0),
+        ));
+    }
+
+    #[test]
+    fn resize_right_shrink() {
+        assert_eq!(resize_right_frame(
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(100.0, 100.0),
+            ),
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(50.0, 50.0),
+            ),
+            -10.,
+            30.,
+        ), CGRect::new(
+            CGPoint::new(0.0, 0.0),
+            CGSize::new(40.0, 50.0),
+        ));
+    }
+
+    #[test]
+    fn resize_right_min_width() {
+        assert_eq!(resize_right_frame(
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(100.0, 100.0),
+            ),
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(50.0, 50.0),
+            ),
+            -50.,
+            30.,
+        ), CGRect::new(
+            CGPoint::new(0.0, 0.0),
+            CGSize::new(30.0, 50.0),
+        ));
+    }
+
+    #[test]
+    fn resize_right_restrict_parent_width() {
+        assert_eq!(resize_right_frame(
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(100.0, 100.0),
+            ),
+            CGRect::new(
+                CGPoint::new(50.0, 0.0),
+                CGSize::new(50.0, 50.0),
+            ),
+            120.,
+            30.,
+        ), CGRect::new(
+            CGPoint::new(50.0, 0.0),
+            CGSize::new(50.0, 50.0),
+        ));
+    }
+
+    #[test]
+    fn resize_top_expand() {
+        assert_eq!(resize_top_frame(
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(100.0, 100.0),
+            ),
+            CGRect::new(
+                CGPoint::new(50.0, 0.0),
+                CGSize::new(10.0, 10.0),
+            ),
+            -20.,
+            20.,
+        ), CGRect::new(
+            CGPoint::new(50.0, 0.0),
+            CGSize::new(10.0, 30.0),
+        ));
+    }
+
+    #[test]
+    fn resize_top_strict_parent_size() {
+        assert_eq!(resize_top_frame(
+            CGRect::new(
+                CGPoint::new(0.0, 0.0),
+                CGSize::new(100.0, 100.0),
+            ),
+            CGRect::new(
+                CGPoint::new(50.0, 50.0),
+                CGSize::new(10.0, 10.0),
+            ),
+            -100.,
+            20.,
+        ), CGRect::new(
+            CGPoint::new(50.0, 50.0),
+            CGSize::new(10.0, 50.0),
+        ));
+    }
+}


### PR DESCRIPTION
On macOS, child windows aren't created within the parent window's area, and the function to achieve that isn't provided by default, so it's implemented by force. Therefore, there are some bugs in detail.

For example, the resize cursor may not be displayed correctly.